### PR TITLE
Add documentation for custom LaTeX packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,10 @@
 
 A collection of custom style packages, designed for personal use.
 
-- [Psalms](#psalms-package)
+- [Liturgical Booklet](liturgicalbooklet/README.md)
+- [Psalms](psalms/README.md)
+- [Rubrics](rubrics/README.md)
+- [Sermon](sermon/README.md)
 
 ## How to use (macOS guide)
 

--- a/liturgicalbooklet/README.md
+++ b/liturgicalbooklet/README.md
@@ -1,0 +1,24 @@
+# Liturgical Booklet Package
+
+A LaTeX package for building small liturgical booklets with chant notation.
+
+## Features
+
+- Sets up a compact page layout and basic fonts.
+- Integrates with GregorioTeX for chant scores.
+- Provides helper commands for colored text, rubrics, versicles, psalms and canticles.
+- Includes macros for lessons, responsories and prayers used in Tenebræ booklets.
+
+## Usage
+
+```tex
+\usepackage{liturgicalbooklet}
+
+% Create a title page with an image
+\mytitle{Good Friday}{cover-image.png}
+
+% Build Psalm 15 in mode 7c without the Gloria
+\buildpsalm{antiphon-file}{15}{7c}
+```
+
+See the package source for the full list of commands.

--- a/psalms/README.md
+++ b/psalms/README.md
@@ -1,2 +1,20 @@
-# Gregorian-Modes
-Compilation of all 150 psalms in every mode, with the first verse in gregorian notation, and the rest of the pslam marked up according to the mode for easy chanting.
+# Psalms Package
+
+Compilation of all 150 psalms in every tone with the first verse in Gregorian
+notation and the remaining verses marked for chanting.
+
+## Usage
+
+```tex
+\usepackage{psalms}
+
+% Psalm 15 in mode 7c without the Gloria Patri
+\psalm[ng]{15}{7c}
+```
+
+The optional argument selects the subdirectory: `g` (with Gloria, default) or
+`ng` (no Gloria). The first mandatory argument is the psalm number and the
+second is the psalm tone.
+
+The package looks for matching score files in `gabc/` and corresponding verse
+markup in the chosen mode directory.

--- a/rubrics/README.md
+++ b/rubrics/README.md
@@ -1,0 +1,19 @@
+# Rubrics Package
+
+Typesetting support for liturgical ceremony notes with red rubric text.
+
+## Features
+
+- Sets up Minion3 as the main font and defines a matching red color.
+- Configures page geometry and two-column layout for compact notes.
+- Optional `chant` and `final` package options load `gregoriotex` and `microtype` respectively.
+- Commands for numbered rubrics: `\rubric`, `\rubricC`, `\rubricD`, and `\rubricSD`.
+- Helper symbols like `\cross`, `\rbar`, and `\vbar` for liturgical cues.
+
+## Usage
+
+```tex
+\usepackage[chant]{rubrics}
+
+\rubric The celebrant kneels.
+```

--- a/sermon/README.md
+++ b/sermon/README.md
@@ -1,0 +1,12 @@
+# Sermon Package
+
+A minimal package for sermon documents. At present it only declares the
+package and provides a place for future macros.
+
+## Usage
+
+```tex
+\usepackage{sermon}
+```
+
+The package currently defines no additional commands.


### PR DESCRIPTION
## Summary
- document liturgicalbooklet package with features and usage
- expand psalms README and clarify \psalm command
- add rubrics and sermon package READMEs and link all packages from root

## Testing
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_68c148740aec8326a82d66445f1be636